### PR TITLE
[Feature] record/FlavorSliderGroup 컴포넌트 추가

### DIFF
--- a/src/assets/styles/themes/_color.module.scss
+++ b/src/assets/styles/themes/_color.module.scss
@@ -9,6 +9,7 @@ $lightPurple100: #b2a1e1;
 $lightPurple200: #a88df4;
 $lightPurple300: #7855da;
 
+$grey50: #f9f9f9;
 $grey100: #eeeeee;
 $grey200: #d9d9d9;
 $grey300: #adadad;
@@ -28,6 +29,7 @@ $grey600: #0c0c0c;
   lightPurple200: $lightPurple200;
   lightPurple300: $lightPurple300;
 
+  grey50: $grey50;
   grey100: $grey100;
   grey200: $grey200;
   grey300: $grey300;

--- a/src/features/record/FlavorSliderGroup/FlavorSliderGroup.module.scss
+++ b/src/features/record/FlavorSliderGroup/FlavorSliderGroup.module.scss
@@ -1,0 +1,18 @@
+@use '~@styles/themes';
+
+.flavor-slider-group {
+  display: grid;
+  grid-template-columns: 22px 1fr;
+  gap: 13px 17px;
+  width: 100%;
+  padding: 19px 27px 9px 27px;
+  border-radius: 10px;
+  background-color: themes.$grey50;
+
+  > label {
+    color: themes.$grey400;
+
+    @include themes.typography("caption11")
+  }
+}
+

--- a/src/features/record/FlavorSliderGroup/FlavorSliderGroup.stories.tsx
+++ b/src/features/record/FlavorSliderGroup/FlavorSliderGroup.stories.tsx
@@ -1,0 +1,11 @@
+import FlavorSliderGroup from './FlavorSliderGroup';
+import type { Meta, StoryObj } from '@storybook/react';
+
+export default {
+  component: FlavorSliderGroup,
+  argTypes: {
+    readOnly: { type: 'boolean', defaultValue: false },
+  },
+} as Meta<typeof FlavorSliderGroup>;
+
+export const Default: StoryObj<typeof FlavorSliderGroup> = {};

--- a/src/features/record/FlavorSliderGroup/FlavorSliderGroup.tsx
+++ b/src/features/record/FlavorSliderGroup/FlavorSliderGroup.tsx
@@ -1,0 +1,69 @@
+import classNames from 'classnames/bind';
+import { useState } from 'react';
+import Slider from '@/shared/components/Slider';
+
+import styles from './FlavorSliderGroup.module.scss';
+
+const cx = classNames.bind(styles);
+
+type FlavorSliderGroupProps = {
+  readOnly?: boolean;
+};
+
+type Flavor = {
+  aroma?: number;
+  taste?: number;
+  texture?: number;
+};
+
+const FlavorSliderGroup = ({ readOnly = false }: FlavorSliderGroupProps) => {
+  const [value, setValue] = useState<Flavor>({
+    aroma: undefined,
+    taste: undefined,
+    texture: undefined,
+  });
+
+  const handleSliderChange = (name: keyof Flavor) => (sliderValue: number) => {
+    setValue((prev) => ({ ...prev, [name]: sliderValue }));
+  };
+
+  return (
+    <div className={cx('flavor-slider-group')}>
+      <label htmlFor="aroma">향</label>
+      <Slider
+        name="aroma"
+        value={value.aroma}
+        onChange={handleSliderChange('aroma')}
+        min={1}
+        max={5}
+        minLabel="별로다"
+        maxLabel="좋다"
+        readOnly={readOnly}
+      />
+      <label htmlFor="taste">맛</label>
+      <Slider
+        name="taste"
+        value={value.taste}
+        onChange={handleSliderChange('taste')}
+        min={1}
+        max={5}
+        minLabel="달다"
+        maxLabel="쓰다"
+        readOnly={readOnly}
+      />
+      <label htmlFor="texture">감촉</label>
+      <Slider
+        name="texture"
+        value={value.texture}
+        onChange={handleSliderChange('texture')}
+        min={1}
+        max={5}
+        minLabel="부드러운"
+        maxLabel="자극적인"
+        readOnly={readOnly}
+      />
+    </div>
+  );
+};
+
+export default FlavorSliderGroup;

--- a/src/features/record/FlavorSliderGroup/index.ts
+++ b/src/features/record/FlavorSliderGroup/index.ts
@@ -1,0 +1,1 @@
+export { default } from './FlavorSliderGroup';

--- a/src/shared/components/Slider/Slider.module.scss
+++ b/src/shared/components/Slider/Slider.module.scss
@@ -24,7 +24,7 @@
 
 @mixin thumbStyles {
   @include markStyles;
-  background: themes.$purple;
+  background: transparent;
 }
 
 .slider-wrapper {

--- a/src/shared/components/Slider/Slider.stories.tsx
+++ b/src/shared/components/Slider/Slider.stories.tsx
@@ -11,6 +11,7 @@ export default {
     minLabel: { type: 'string' },
     maxLabel: { type: 'string' },
     useDebounce: { type: 'boolean', defaultValue: false },
+    readOnly: { type: 'boolean', defaultValue: false },
   },
 } as Meta<typeof Slider>;
 
@@ -30,26 +31,30 @@ export const Default: StoryFn<typeof Slider> = (args) => {
   );
 };
 
+const flavorSliderArgs = {
+  value: 3,
+  min: 1,
+  max: 5,
+  step: 1,
+  minLabel: '달다',
+  maxLabel: '쓰다',
+  style: { width: '200px' },
+};
+
 export const FlavorSlider: StoryObj<typeof Slider> = {
-  args: {
-    value: 3,
-    min: 1,
-    max: 5,
-    step: 1,
-    minLabel: '달다',
-    maxLabel: '쓰다',
-    style: { width: '200px' },
-  },
+  args: flavorSliderArgs,
 };
 
 export const WithNoValue: StoryObj<typeof Slider> = {
   args: {
+    ...flavorSliderArgs,
     value: undefined,
-    min: 1,
-    max: 5,
-    step: 1,
-    minLabel: '달다',
-    maxLabel: '쓰다',
-    style: { width: '200px' },
+  },
+};
+
+export const ReadOnly: StoryObj<typeof Slider> = {
+  args: {
+    ...flavorSliderArgs,
+    readOnly: true,
   },
 };

--- a/src/shared/components/Slider/Slider.stories.tsx
+++ b/src/shared/components/Slider/Slider.stories.tsx
@@ -41,3 +41,15 @@ export const FlavorSlider: StoryObj<typeof Slider> = {
     style: { width: '200px' },
   },
 };
+
+export const WithNoValue: StoryObj<typeof Slider> = {
+  args: {
+    value: undefined,
+    min: 1,
+    max: 5,
+    step: 1,
+    minLabel: '달다',
+    maxLabel: '쓰다',
+    style: { width: '200px' },
+  },
+};

--- a/src/shared/components/Slider/Slider.tsx
+++ b/src/shared/components/Slider/Slider.tsx
@@ -18,6 +18,7 @@ type SliderProps = {
   name?: string;
   onChange?: (value: number) => void;
   useDebounce?: boolean;
+  readOnly?: boolean;
 };
 
 const Slider = ({
@@ -32,6 +33,7 @@ const Slider = ({
   name,
   onChange,
   useDebounce = false,
+  readOnly = false,
 }: SliderProps) => {
   const [value, setValue] = useState(outerValue);
 
@@ -48,12 +50,13 @@ const Slider = ({
 
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
+      if (readOnly) return;
+
       const currentValue = parseInt(e.target.value);
       setValue(currentValue);
-
       (useDebounce ? debouncedChange : onChange)?.(currentValue);
     },
-    [debouncedChange, onChange, useDebounce]
+    [debouncedChange, onChange, readOnly, useDebounce]
   );
 
   return (
@@ -84,6 +87,7 @@ const Slider = ({
           value={value}
           onChange={handleChange}
           name={name}
+          readOnly={readOnly}
         />
       </div>
       <div className={cx('labels')}>

--- a/src/shared/components/Slider/Slider.tsx
+++ b/src/shared/components/Slider/Slider.tsx
@@ -1,13 +1,13 @@
 import classNames from 'classnames/bind';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { debounce } from 'lodash-es';
+import { debounce, isNil } from 'lodash-es';
 
 import styles from './Slider.module.scss';
 
 const cx = classNames.bind(styles);
 
 type SliderProps = {
-  value: number;
+  value?: number;
   min?: number;
   max?: number;
   step?: number;
@@ -15,7 +15,8 @@ type SliderProps = {
   maxLabel?: string;
   className?: string;
   style?: React.CSSProperties;
-  onChange: (value: number) => void;
+  name?: string;
+  onChange?: (value: number) => void;
   useDebounce?: boolean;
 };
 
@@ -28,25 +29,29 @@ const Slider = ({
   step = 1,
   className,
   style,
+  name,
   onChange,
   useDebounce = false,
 }: SliderProps) => {
   const [value, setValue] = useState(outerValue);
 
-  const railPercent = ((value - min) / (max - min)) * 100;
+  const railPercent = isNil(value) ? 0 : ((value - min) / (max - min)) * 100;
 
   useEffect(() => {
     setValue(outerValue);
   }, [outerValue]);
 
-  const debouncedChange = useMemo(() => debounce(onChange, 300), [onChange]);
+  const debouncedChange = useMemo(
+    () => onChange && debounce(onChange, 300),
+    [onChange]
+  );
 
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const currentValue = parseInt(e.target.value);
       setValue(currentValue);
 
-      useDebounce ? debouncedChange(currentValue) : onChange(currentValue);
+      (useDebounce ? debouncedChange : onChange)?.(currentValue);
     },
     [debouncedChange, onChange, useDebounce]
   );
@@ -65,7 +70,7 @@ const Slider = ({
                 key={markValue}
                 className={cx('mark', {
                   'mark--visible': index % step === 0,
-                  'mark--filled': markValue <= value,
+                  'mark--filled': !isNil(value) && markValue <= value,
                 })}
               />
             ))}
@@ -78,6 +83,7 @@ const Slider = ({
           step={step}
           value={value}
           onChange={handleChange}
+          name={name}
         />
       </div>
       <div className={cx('labels')}>


### PR DESCRIPTION
1. FlavorSliderGroup 컴포넌트 추가
    - value 타입의 경우 추후 api 로직 붙일때 수정하는 것이 좋을 것 같습니다! (reat hook form 사용 등)
3. Slider 컴포넌트 수정 사항
    - readOnly 속성 추가
    - value, onChange -> optional로 변경  (값에 undefined 가능하도록)
    - thumb 색상 투명으로 변경
4. grey50 색상 추가  (grey100보다 더 밝은 색을 사용하는데, grey100으로 대체하기에는 차이가 꽤 나는 것 같아서 추가했습니다)
 
![FlavorSliderGroup](https://user-images.githubusercontent.com/39763891/215341958-5fd4f5b9-1692-4d16-99fc-8a738107fa61.gif)
