### PR TITLE
[Feature] Icon 컴포넌트 color props 추가

### DIFF
--- a/src/assets/styles/themes/index.ts
+++ b/src/assets/styles/themes/index.ts
@@ -1,0 +1,13 @@
+// TODO : grey50 추가
+export type Color =
+  | 'white'
+  | 'black'
+  | 'purple'
+  | `purpleOpacity${5 | 60}`
+  | `lightPurple${100 | 200 | 300}`
+  | `grey${100 | 200 | 300 | 400 | 500 | 600}`;
+
+export type Typography =
+  | `title${40 | 26 | 20 | 18}`
+  | `body${16 | 15 | 14 | 13}`
+  | `caption${12 | 11 | 10}`;

--- a/src/shared/components/Icon/Icon.module.scss
+++ b/src/shared/components/Icon/Icon.module.scss
@@ -1,3 +1,88 @@
+@use '~@styles/themes/color.module';
+
+// TODO: grey50추가
 .icon {
-  // TODO: theme에 따른 color 지정
+  &.white {
+    path{
+      fill: color.$white;
+    }
+  }
+
+  &.black {
+    path{
+      fill: color.$black;
+    }
+  }
+
+  &.purple {
+    path{
+      fill: color.$purple;
+    }
+  }
+
+  &.purpleOpacity5 {
+    path{
+      fill: color.$purpleOpacity5;
+    }
+  }
+
+  &.purpleOpacity60 {
+    path{
+      fill: color.$purpleOpacity60;
+    }
+  }
+
+  &.lightPurple100 {
+    path{
+      fill: color.$lightPurple100;
+    }
+  }
+
+  &.lightPurple200 {
+    path{
+      fill: color.$lightPurple200;
+    }
+  }
+
+  &.lightPurple300 {
+    path{
+      fill: color.$lightPurple300;
+    }
+  }
+
+  &.grey100 {
+    path{
+      fill: color.$grey100;
+    }
+  }
+
+  &.grey200 {
+    path{
+      fill: color.$grey200;
+    }
+  }
+
+  &.grey300 {
+    path{
+      fill: color.$grey300;
+    }
+  }
+
+  &.grey400 {
+    path{
+      fill: color.$grey400;
+    }
+  }
+
+  &.grey500 {
+    path{
+      fill: color.$grey500;
+    }
+  }
+
+  &.grey600 {
+    path{
+      fill: color.$grey600;
+    }
+  }
 }

--- a/src/shared/components/Icon/Icon.tsx
+++ b/src/shared/components/Icon/Icon.tsx
@@ -1,7 +1,8 @@
 import { SVGProps } from 'react';
-
 import classNames from 'classnames/bind';
 import * as icons from '@/assets/icons';
+import { Color } from '@/assets/styles/themes';
+
 import styles from './Icon.module.scss';
 
 const cx = classNames.bind(styles);
@@ -13,8 +14,7 @@ interface IconProps extends SVGProps<SVGSVGElement> {
   size?: number;
   width?: string;
   height?: string;
-  // TODO: theme 추가 후 color prop 타입 수정
-  color?: string;
+  color?: Color;
 }
 
 const DEFAULT_SIZE = 30;


### PR DESCRIPTION
<img width="973" alt="image" src="https://user-images.githubusercontent.com/39763891/215345248-fb950435-694f-4fe3-93c6-7402f50f9507.png">

TODO
- https://github.com/sullog-official/sullog-client/pull/14#issue-1561370867 머지되면 grey50 관련 코드도 추가