### PR TITLE
fix: 마포꽃섬 폰트 적용 안되는 이슈 수정

### DIFF
--- a/src/assets/styles/fonts/index.ts
+++ b/src/assets/styles/fonts/index.ts
@@ -8,4 +8,5 @@ export const mapoFlowerIsland = localFont({
       style: 'italic',
     },
   ],
+  variable: '--mapo-flower-island-font',
 });

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,18 +1,7 @@
 import type { AppProps } from 'next/app';
 
-import { mapoFlowerIsland } from '@/assets/styles/fonts';
-
 import '@/assets/styles/index.scss';
 
 export default function App({ Component, pageProps }: AppProps) {
-  return (
-    <>
-      <style jsx global>{`
-        :root {
-          --mapo-flower-island-font: ${mapoFlowerIsland.style.fontFamily};
-        }
-      `}</style>
-      <Component {...pageProps} />
-    </>
-  );
+  return <Component {...pageProps} />;
 }

--- a/src/pages/index.module.scss
+++ b/src/pages/index.module.scss
@@ -7,7 +7,6 @@
 .header-text {
   padding-bottom: 20px;
   color: themes.$purple;
-  font-family: var(--mapo-flower-island-font);
   @include themes.typography('body16');
 }
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames/bind';
 
+import { mapoFlowerIsland } from '@/assets/styles/fonts';
 import Map from '@/features/home/components/Map';
 import SearchBar from '@/features/search/SearchBar';
 import BottomNavigator from '@/shared/components/BottomNavigator';
@@ -12,7 +13,9 @@ export default function Home() {
   return (
     <main className={cx('main')}>
       <div className={cx('header')}>
-        <h1 className={cx('header-text')}>나의 술로그</h1>
+        <h1 className={cx('header-text')} style={mapoFlowerIsland.style}>
+          나의 술로그
+        </h1>
         <SearchBar placeholder={'Search'} />
       </div>
       <Map

--- a/src/pages/login/Login.module.scss
+++ b/src/pages/login/Login.module.scss
@@ -18,24 +18,25 @@
 
 .main-title {
   @include themes.typography('title40');
-  font-family: var(--mapo-flower-island-font);
-  color: themes.$white;
+
   display: flex;
   flex-direction: column;
+  color: themes.$white;
 }
 
 .sub-title {
   @include themes.typography('body14');
-  color: themes.$lightPurple100
+
+  color: themes.$lightPurple100;
 }
 
 .button-wrapper {
+  display: flex;
   position: absolute;
   bottom: 46px;
-  width: 100%;
-  display: flex;
   flex-direction: column;
   align-items: center;
+  width: 100%;
   padding: 0 15px;
 }
 
@@ -46,9 +47,9 @@
   justify-content: center;
   width: 100%;
   height: 48px;
-  border-radius: 6px;
   margin-bottom: 8px;
-  background-color: #FEE500;
+  border-radius: 6px;
+  background-color: #fee500;
   @include themes.typography('body16');
 }
 
@@ -56,7 +57,7 @@
   width: 100%;
   height: 48px;
   border-radius: 6px;
-  background-color: #03C75A;
+  background-color: #03c75a;
   color: themes.$white;
   @include themes.typography('body16');
 }
@@ -65,9 +66,9 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  margin-top: 14px;
   color: themes.$grey200;
   font-size: 10px;
-  margin-top: 14px;
 }
 
 .terms-of-service-modal-btn {

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames/bind';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 
+import { mapoFlowerIsland } from '@/assets/styles/fonts';
 import { kakaoLoginCallback } from '@/shared/apis/auth/kakaoLogin';
 import Icon from '@/shared/components/Icon';
 import { TokenKeys } from '@/shared/configs/axios';
@@ -46,7 +47,7 @@ const Login = () => {
   return (
     <main className={cx('wrapper')}>
       <div className={cx('title-wrapper')}>
-        <h1 className={cx('main-title')}>
+        <h1 className={cx('main-title')} style={mapoFlowerIsland.style}>
           <span>술로그</span>
           <span className={cx('sub-title')}>전통주를 기록하다</span>
         </h1>

--- a/src/shared/components/TopNavigator/TopNavigator.module.scss
+++ b/src/shared/components/TopNavigator/TopNavigator.module.scss
@@ -19,7 +19,6 @@
 
   &.personal {
     color: themes.$purple;
-    font-family: var(--mapo-flower-island-font);
     @include themes.typography('body16');
   }
 }

--- a/src/shared/components/TopNavigator/TopNavigator.tsx
+++ b/src/shared/components/TopNavigator/TopNavigator.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames/bind';
 
+import { mapoFlowerIsland } from '@/assets/styles/fonts';
 import Icon from '@/shared/components/Icon';
 
 import styles from './TopNavigator.module.scss';
@@ -17,7 +18,12 @@ const TopNavigator = ({ type, title, isCompleted }: TopNavigatorProps) => {
       <button type="button" aria-label="Back" className={cx('back-btn')}>
         <Icon name={'Back'} size={12} />
       </button>
-      <h1 className={cx('title', type)}>{title}</h1>
+      <h1
+        className={cx('title', type)}
+        style={type === 'personal' ? mapoFlowerIsland.style : {}}
+      >
+        {title}
+      </h1>
       {type === 'writing' && (
         <button type="button" className={cx('write-btn')}>
           <span className={cx('write-label', isCompleted)}>완료</span>


### PR DESCRIPTION
마포 꽃섬 폰트 적용 방법 style에 mapoFlowerIsland.style을 주면 됩니다.
```jsx
import { mapoFlowerIsland } from '@/assets/styles/fonts';

<h1 className={cx('header-text')} style={mapoFlowerIsland.style}>
      나의 술로그
</h1>
```

<img width="455" alt="image" src="https://user-images.githubusercontent.com/39763891/232233128-36aacb23-4026-4171-bc23-f63ac36e1d47.png">
