### PR TITLE
refactor: TopNavigator 리팩토링

### DIFF
--- a/src/pages/list/index.tsx
+++ b/src/pages/list/index.tsx
@@ -28,7 +28,7 @@ const List = () => {
 
   return (
     <>
-      <TopNavigator type={'personal'} title={'나의 술로그'} />
+      <TopNavigator title={'나의 술로그'} highlighted />
       <main>
         <AlcoholCategoryTab
           alcoholCategories={AlcoholCategories}

--- a/src/pages/my-search/index.tsx
+++ b/src/pages/my-search/index.tsx
@@ -34,7 +34,7 @@ const MySearch = () => {
 
   return (
     <>
-      <TopNavigator type={'personal'} title={'나의 술로그'} />
+      <TopNavigator title={'나의 술로그'} highlighted />
       <main className={cx('wrapper')}>
         <div className={cx('search-bar-wrapper')}>
           <SearchBar placeholder={'Search'} />

--- a/src/shared/components/TopNavigator/TopNavigator.module.scss
+++ b/src/shared/components/TopNavigator/TopNavigator.module.scss
@@ -1,39 +1,43 @@
 @use '@styles/themes';
 
+$height: 56.4px;
+
 .wrapper {
   display: flex;
+  position: relative;
   flex-direction: row;
   align-items: center;
   justify-content: center;
-  height: 56.4px;
+  height: $height;
 }
 
+$backButtonWidth: 40px;
+$iconWidth: 12px;
+
 .back-btn {
+  display: flex;
   position: absolute;
-  left: 28px;
+  left: calc(28px - ($backButtonWidth - $iconWidth) / 2);
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 100%;
 }
 
 .title {
   color: themes.$black;
   @include themes.typography('body15');
 
-  &.personal {
+  &.highlighted {
     color: themes.$purple;
     @include themes.typography('body16');
   }
 }
 
-.write-btn {
+.extra {
+  display: flex;
   position: absolute;
   right: 28px;
-}
-
-.write-label {
-  @include themes.typography('body14');
-
-  color: themes.$grey200;
-
-  &.completed {
-    color: themes.$black;
-  }
+  align-items: center;
+  height: 100%;
 }

--- a/src/shared/components/TopNavigator/TopNavigator.stories.tsx
+++ b/src/shared/components/TopNavigator/TopNavigator.stories.tsx
@@ -8,28 +8,31 @@ export default {
 
 export const Default: StoryObj<typeof TopNavigator> = {
   args: {
-    type: 'default',
     title: '게시글',
   },
 };
 
 export const MySullog: StoryObj<typeof TopNavigator> = {
   args: {
-    type: 'personal',
     title: '나의 술로그',
+    highlighted: true,
   },
 };
 
 export const NeighborsSullog: StoryObj<typeof TopNavigator> = {
   args: {
-    type: 'personal',
     title: '이웃 술로그',
+    highlighted: true,
   },
 };
 
 export const Writing: StoryObj<typeof TopNavigator> = {
   args: {
-    type: 'writing',
     title: '게시글',
+    extra: (
+      <button type="button" style={{ fontSize: '13px', lineHeight: '16px' }}>
+        완료
+      </button>
+    ),
   },
 };

--- a/src/shared/components/TopNavigator/TopNavigator.tsx
+++ b/src/shared/components/TopNavigator/TopNavigator.tsx
@@ -1,4 +1,5 @@
 import classNames from 'classnames/bind';
+import { useRouter } from 'next/router';
 
 import { mapoFlowerIsland } from '@/assets/styles/fonts';
 import Icon from '@/shared/components/Icon';
@@ -7,28 +8,37 @@ import styles from './TopNavigator.module.scss';
 const cx = classNames.bind(styles);
 
 type TopNavigatorProps = {
-  type: 'default' | 'personal' | 'writing';
   title: string;
-  isCompleted?: boolean;
+  onBack?: VoidFunction;
+  extra?: React.ReactNode;
+  highlighted?: boolean;
 };
 
-const TopNavigator = ({ type, title, isCompleted }: TopNavigatorProps) => {
+const TopNavigator = ({
+  title,
+  onBack,
+  extra,
+  highlighted,
+}: TopNavigatorProps) => {
+  const router = useRouter();
+
   return (
     <nav className={cx('wrapper')}>
-      <button type="button" aria-label="Back" className={cx('back-btn')}>
-        <Icon name={'Back'} size={12} />
+      <button
+        type="button"
+        aria-label="뒤로가기"
+        className={cx('back-btn')}
+        onClick={onBack ?? router.back}
+      >
+        <Icon name="Back" size={12} />
       </button>
       <h1
-        className={cx('title', type)}
-        style={type === 'personal' ? mapoFlowerIsland.style : {}}
+        className={cx('title', { highlighted })}
+        style={highlighted ? mapoFlowerIsland.style : {}}
       >
         {title}
       </h1>
-      {type === 'writing' && (
-        <button type="button" className={cx('write-btn')}>
-          <span className={cx('write-label', isCompleted)}>완료</span>
-        </button>
-      )}
+      {extra && <div className={cx('extra')}>{extra}</div>}
     </nav>
   );
 };


### PR DESCRIPTION
resolve #53

1. 접근성 개선
- aria-label은 스크린리더 사용자가 이해할 수 있는 문구로 지정되어야하므로 '뒤로가기'로 수정했습니다.
- 버튼 클릭 영역이 너무 작아서 수정했습니다.

2. 확장성 있는 컴포넌트로 개선
- 기존 type은 personal, write로 이는 서비스의 기능과 직접적으로 연관되어있기 때문에 추후 확장해 재사용하기 어려운것 같습니다. 
문제 1) 오른쪽에 '수정' 버튼이 있는 마이페이지 내비게이터를 만들어야한다면? -> mypage type이 추가되어한다.
문제 2) button의 disabled, onClick 속성들을 동일하게 네비게이터에도 넘겨줘야한다.

-> type으로 오른쪽 버튼 유무를 제어하던 형태를 extra라는 prop을 사용하도록 수정했습니다.  ([antd PageHeader 참고](https://4x.ant.design/components/page-header/))
이렇게 수정하면 추후 TopNavigator의 extra영역에 어떤 컴포넌트가 위치해도 TopNavigator를 재사용 할 수 있을 것 같습니다.

- 기존 personal(마포 꽃섬 폰트를 사용, 폰트 크기 큰)이었던 타입에 해당하는 스타일은 boolean 타입의 highlighted prop으로 설정가능하도록 수정했습니다.
