### PR TITLE
[FEATURE] useIntersect 훅 작성 및 피드 페이지에 무한 스크롤 적용

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -10,6 +10,10 @@ const nextConfig = {
         protocol: 'https',
         hostname: '**',
       },
+      {
+        protocol: 'http',
+        hostname: 'localhost',
+      },
     ],
   },
   webpack(config) {

--- a/src/pages/feed/index.tsx
+++ b/src/pages/feed/index.tsx
@@ -7,12 +7,13 @@ import { useGetFeed } from '@/shared/apis/feed/getFeed';
 import BottomNavigator from '@/shared/components/BottomNavigator';
 import TopNavigator from '@/shared/components/TopNavigator';
 import useIntersect from '@/shared/hooks/useIntersect';
+import { Feed } from '@/shared/types/feed';
 
 import styles from './index.module.scss';
 
 const cx = classNames.bind(styles);
 
-const Feed = () => {
+const FeedPage = () => {
   const { data, fetchNextPage, hasNextPage, isFetching, isLoading } =
     useGetFeed({
       variables: {
@@ -29,7 +30,13 @@ const Feed = () => {
   });
 
   if (!data) return null;
-  const { allRecordMetaList: feeds, pagingInfo } = data.pages[0];
+
+  const feeds: Feed[] = [];
+  data.pages.map((page) => {
+    page.allRecordMetaList.map((feed) => {
+      feeds.push(feed);
+    });
+  });
 
   return (
     <>
@@ -47,7 +54,7 @@ const Feed = () => {
   );
 };
 
-export default Feed;
+export default FeedPage;
 
 export const getServerSideProps: GetServerSideProps<{
   dehydratedState: DehydratedState;

--- a/src/pages/feed/index.tsx
+++ b/src/pages/feed/index.tsx
@@ -30,13 +30,7 @@ const FeedPage = () => {
   });
 
   if (!data) return null;
-
-  const feeds: Feed[] = [];
-  data.pages.map((page) => {
-    page.allRecordMetaList.map((feed) => {
-      feeds.push(feed);
-    });
-  });
+  const feeds: Feed[] = data.pages.flatMap((page) => page.allRecordMetaList);
 
   return (
     <>

--- a/src/pages/feed/index.tsx
+++ b/src/pages/feed/index.tsx
@@ -1,23 +1,31 @@
 import { dehydrate, DehydratedState, QueryClient } from '@tanstack/react-query';
 import classNames from 'classnames/bind';
 import { GetServerSideProps } from 'next';
-import { useState } from 'react';
 
 import Card from '@/features/feed/components/Card';
 import { useGetFeed } from '@/shared/apis/feed/getFeed';
 import BottomNavigator from '@/shared/components/BottomNavigator';
 import TopNavigator from '@/shared/components/TopNavigator';
+import useIntersect from '@/shared/hooks/useIntersect';
 
 import styles from './index.module.scss';
 
 const cx = classNames.bind(styles);
 
 const Feed = () => {
-  const [cursor, setCursor] = useState(0);
-  const [limit, setLimit] = useState(8);
+  const { data, fetchNextPage, hasNextPage, isFetching, isLoading } =
+    useGetFeed({
+      variables: {
+        cursor: 0,
+        limit: 8,
+      },
+    });
 
-  const { data, fetchNextPage, hasNextPage, isLoading } = useGetFeed({
-    variables: { cursor, limit },
+  const ref = useIntersect(async (entry, observer) => {
+    observer.unobserve(entry.target);
+    if (hasNextPage && !isFetching) {
+      fetchNextPage();
+    }
   });
 
   if (!data) return null;
@@ -32,6 +40,7 @@ const Feed = () => {
             <Card alt={feed.alcoholName} imageUrl={feed.mainPhotoPath} />
           </button>
         ))}
+        <div ref={ref} />
       </main>
       <BottomNavigator />
     </>
@@ -44,8 +53,9 @@ export const getServerSideProps: GetServerSideProps<{
   dehydratedState: DehydratedState;
 }> = async () => {
   const queryClient = new QueryClient();
+
   await queryClient.prefetchQuery(
-    useGetFeed.getKey({ limit: 8 }),
+    useGetFeed.getKey({ cursor: 0, limit: 8 }),
     useGetFeed.queryFn
   );
 

--- a/src/shared/apis/feed/getFeed.ts
+++ b/src/shared/apis/feed/getFeed.ts
@@ -4,17 +4,12 @@ import { Feed } from '@/shared/types/feed';
 import { PagingInfo } from '@/shared/types/paging';
 import { request } from '@/shared/utils/request';
 
-type Variables = {
-  cursor: number;
-  limit: number;
-};
-
 type Response = {
   allRecordMetaList: Feed[];
   pagingInfo: PagingInfo;
 };
 
-const getFeed = ({ cursor, limit }: Variables) => {
+const getFeed = ({ cursor, limit }: PagingInfo) => {
   return request<Response>({
     method: 'get',
     url: `records?${cursor ? `cursor=${cursor}` : ''}&limit=${limit}`,
@@ -23,6 +18,10 @@ const getFeed = ({ cursor, limit }: Variables) => {
 
 export const useGetFeed = createInfiniteQuery({
   primaryKey: '/feed',
-  queryFn: ({ queryKey: [, variables] }) => getFeed(variables),
-  getNextPageParam: ({ pagingInfo }) => pagingInfo.cursor,
+  queryFn: ({ pageParam }) => getFeed({ cursor: pageParam?.cursor, limit: 8 }),
+  getNextPageParam: (lastPage) => {
+    if (lastPage.pagingInfo.cursor) {
+      return { cursor: lastPage.pagingInfo.cursor };
+    }
+  },
 });

--- a/src/shared/hooks/useIntersect.ts
+++ b/src/shared/hooks/useIntersect.ts
@@ -1,0 +1,32 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+type IntersectHandler = (
+  entry: IntersectionObserverEntry,
+  observer: IntersectionObserver
+) => void;
+
+const useIntersect = (
+  onIntersect: IntersectHandler,
+  options?: IntersectionObserverInit
+) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const callback = useCallback(
+    (entries: IntersectionObserverEntry[], observer: IntersectionObserver) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) onIntersect(entry, observer);
+      });
+    },
+    [onIntersect]
+  );
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const observer = new IntersectionObserver(callback, options);
+    observer.observe(ref.current);
+    return () => observer.disconnect(); // 클린업
+  }, [ref, options, callback]);
+
+  return ref;
+};
+
+export default useIntersect;


### PR DESCRIPTION
- intersection observer api를 활용하여 useIntersect 훅을 작성하였습니다.
  - 무한 스크롤이 필요한 페이지에 적용하기 위해 공통 훅으로 관리하였습니다.
```typescript
import { useCallback, useEffect, useRef } from 'react';

type IntersectHandler = (
  entry: IntersectionObserverEntry,
  observer: IntersectionObserver
) => void;

const useIntersect = (
  onIntersect: IntersectHandler,
  options?: IntersectionObserverInit
) => {
  const ref = useRef<HTMLDivElement>(null);
  const callback = useCallback(
    (entries: IntersectionObserverEntry[], observer: IntersectionObserver) => {
      entries.forEach((entry) => {
        if (entry.isIntersecting) onIntersect(entry, observer);
      });
    },
    [onIntersect]
  );

  useEffect(() => {
    if (!ref.current) return;
    const observer = new IntersectionObserver(callback, options);
    observer.observe(ref.current);
    return () => observer.disconnect(); // 클린업
  }, [ref, options, callback]);

  return ref;
};

export default useIntersect;
```

- 피드 페이지에 무한 스크롤을 적용하였습니다.
  - 현재 일부 이미지에 이슈가 있어 정상적으로 보이지는 않습니다.