### PR TITLE
[FEATURE] 경험 통계 실제 데이터 연동

### DIFF
--- a/src/features/home/components/DrawerContents/DrawerContents.tsx
+++ b/src/features/home/components/DrawerContents/DrawerContents.tsx
@@ -4,27 +4,32 @@ import { mapoFlowerIsland } from '@/assets/styles/fonts';
 import DoughnutChart from '@/features/home/components/DoughnutChart';
 import logout from '@/shared/apis/auth/logout';
 import { Button } from '@/shared/components';
+import { Statistics } from '@/shared/types/record/statistics';
 
 import styles from './DrawerContents.module.scss';
 
 const cx = classNames.bind(styles);
 
-const DrawerContents = () => {
+type DrawerContentsProps = {
+  statistics?: Statistics;
+};
+
+const DrawerContents = ({ statistics }: DrawerContentsProps) => {
+  // TODO 글쓰기 기능 연결하고 실제 통계 데이터 출력
   return (
     <div className={cx('wrapper')}>
       <div className={cx('title-box')}>
         <p>
-          <span className={cx('name')}>이짱구</span>님 환영해요!
+          <span className={cx('name')}>{statistics?.nickname}</span>님 환영해요!
         </p>
         <p>오늘도 나만의 술로그를 남겨보아요</p>
       </div>
       <div className={cx('chart-container')}>
         <p style={mapoFlowerIsland.style}>나의 술로그</p>
         <DoughnutChart />
-        <p>술짱조아 님은 10개의 술로그를 남겨주었어요</p>
+        <p>{statistics?.nickname}님은 10개의 술로그를 남겨주었어요</p>
       </div>
       <div className={cx('button-container')}>
-        {/*TODO: 문의하기 기능에 대한 논의 필요*/}
         <Button>문의하기</Button>
         <Button type="outline" onClick={logout}>
           로그아웃

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,15 +4,12 @@ import { GetServerSideProps } from 'next';
 import { useState } from 'react';
 
 import { mapoFlowerIsland } from '@/assets/styles/fonts';
-import DrawerContents from '@/features/home/components/DrawerContents';
 import Map from '@/features/home/components/Map';
 import SearchBar from '@/features/search/components/SearchBar';
 import { useGetMyRecord } from '@/shared/apis/records/getMyRecord';
 import { useGetStatistics } from '@/shared/apis/records/getStatistics';
 import BottomNavigator from '@/shared/components/BottomNavigator';
-import Drawer from '@/shared/components/Drawer';
 import PageLayout from '@/shared/components/PageLayout';
-import { useModal } from '@/shared/hooks/useModal';
 
 import styles from './index.module.scss';
 
@@ -24,8 +21,6 @@ export default function Home() {
 
   const [searchValue, setSearchValue] = useState('');
   const [selectedFilter, setSelectedFilter] = useState<string[]>([]);
-
-  const [isDrawerOpen, openDrawer, closeDrawer] = useModal();
 
   const filteredRecords = records.filter((record) =>
     selectedFilter.includes(record.alcoholTag)
@@ -56,10 +51,7 @@ export default function Home() {
         />
       </div>
       <Map records={selectedFilter.length > 0 ? filteredRecords : records} />
-      <BottomNavigator openDrawer={openDrawer} />
-      <Drawer isOpen={isDrawerOpen} onClose={closeDrawer}>
-        <DrawerContents statistics={statistics} />
-      </Drawer>
+      <BottomNavigator statistics={statistics} />
     </PageLayout>
   );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,4 @@
-import { dehydrate, DehydratedState, QueryClient } from '@tanstack/react-query';
 import classNames from 'classnames/bind';
-import { GetServerSideProps } from 'next';
 import { useState } from 'react';
 
 import { mapoFlowerIsland } from '@/assets/styles/fonts';
@@ -55,20 +53,3 @@ export default function Home() {
     </PageLayout>
   );
 }
-
-export const getServerSideProps: GetServerSideProps<{
-  dehydratedState: DehydratedState;
-}> = async () => {
-  const queryClient = new QueryClient();
-
-  await queryClient.prefetchQuery(
-    useGetStatistics.getKey(),
-    useGetStatistics.queryFn
-  );
-
-  return {
-    props: {
-      dehydratedState: dehydrate(queryClient),
-    },
-  };
-};

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames/bind';
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 
 import { mapoFlowerIsland } from '@/assets/styles/fonts';
 import { kakaoLoginCallback } from '@/shared/apis/auth/kakaoLogin';
@@ -13,7 +13,7 @@ import {
   NEXT_PUBLIC_KAKAO_REDIRECT_URI,
   NEXT_PUBLIC_KAKAO_SCOPE,
 } from '@/shared/constants';
-import { getCookie, setCookie } from '@/shared/utils/cookie';
+import { setCookie } from '@/shared/utils/cookie';
 
 import styles from './index.module.scss';
 

--- a/src/shared/apis/records/getStatistics.ts
+++ b/src/shared/apis/records/getStatistics.ts
@@ -6,7 +6,7 @@ import { request } from '@/shared/utils/request';
 const getStatistics = () => {
   return request<Statistics>({
     method: 'get',
-    url: 'records/me/statistics',
+    url: '/records/me/statistics',
   });
 };
 

--- a/src/shared/apis/records/getStatistics.ts
+++ b/src/shared/apis/records/getStatistics.ts
@@ -1,0 +1,16 @@
+import { createQuery } from 'react-query-kit';
+
+import { Statistics } from '@/shared/types/record/statistics';
+import { request } from '@/shared/utils/request';
+
+const getStatistics = () => {
+  return request<Statistics>({
+    method: 'get',
+    url: 'records/me/statistics',
+  });
+};
+
+export const useGetStatistics = createQuery({
+  primaryKey: '/statistics',
+  queryFn: () => getStatistics(),
+});

--- a/src/shared/apis/records/getStatistics.ts
+++ b/src/shared/apis/records/getStatistics.ts
@@ -12,5 +12,5 @@ const getStatistics = () => {
 
 export const useGetStatistics = createQuery({
   primaryKey: '/statistics',
-  queryFn: () => getStatistics(),
+  queryFn: getStatistics,
 });

--- a/src/shared/components/BottomNavigator/BottomNavigator.tsx
+++ b/src/shared/components/BottomNavigator/BottomNavigator.tsx
@@ -1,20 +1,20 @@
 import classNames from 'classnames/bind';
 import { useRouter } from 'next/router';
-import { useState } from 'react';
 
 import DrawerContents from '@/features/home/components/DrawerContents';
 import Drawer from '@/shared/components/Drawer';
 import Icon from '@/shared/components/Icon';
-import { useModal } from '@/shared/hooks/useModal';
 
 import styles from './BottomNavigator.module.scss';
 
 const cx = classNames.bind(styles);
 
-const BottomNavigator = () => {
-  const router = useRouter();
+type BottomNavigatorProps = {
+  openDrawer?: () => void;
+};
 
-  const [isDrawerOpen, openDrawer, closeDrawer] = useModal();
+const BottomNavigator = ({ openDrawer }: BottomNavigatorProps) => {
+  const router = useRouter();
 
   const navigateToWrite = () => {
     router.push('/alcohols/search');
@@ -51,9 +51,6 @@ const BottomNavigator = () => {
           </button>
         </div>
       </nav>
-      <Drawer isOpen={isDrawerOpen} onClose={closeDrawer}>
-        <DrawerContents />
-      </Drawer>
     </>
   );
 };

--- a/src/shared/components/BottomNavigator/BottomNavigator.tsx
+++ b/src/shared/components/BottomNavigator/BottomNavigator.tsx
@@ -4,17 +4,21 @@ import { useRouter } from 'next/router';
 import DrawerContents from '@/features/home/components/DrawerContents';
 import Drawer from '@/shared/components/Drawer';
 import Icon from '@/shared/components/Icon';
+import { useModal } from '@/shared/hooks/useModal';
+import { Statistics } from '@/shared/types/record/statistics';
 
 import styles from './BottomNavigator.module.scss';
 
 const cx = classNames.bind(styles);
 
 type BottomNavigatorProps = {
-  openDrawer?: () => void;
+  statistics?: Statistics;
 };
 
-const BottomNavigator = ({ openDrawer }: BottomNavigatorProps) => {
+const BottomNavigator = ({ statistics }: BottomNavigatorProps) => {
   const router = useRouter();
+
+  const [isDrawerOpen, openDrawer, closeDrawer] = useModal();
 
   const navigateToWrite = () => {
     router.push('/alcohols/search');
@@ -35,7 +39,6 @@ const BottomNavigator = ({ openDrawer }: BottomNavigatorProps) => {
           <Icon name="Write" size={14} />
           <p>글쓰기</p>
         </button>
-        {/* TODO: button active 시 아이콘 변경 */}
         <div className={cx('container')}>
           <button
             onClick={navigateToFeed}
@@ -51,6 +54,9 @@ const BottomNavigator = ({ openDrawer }: BottomNavigatorProps) => {
           </button>
         </div>
       </nav>
+      <Drawer isOpen={isDrawerOpen} onClose={closeDrawer}>
+        <DrawerContents statistics={statistics} />
+      </Drawer>
     </>
   );
 };

--- a/src/shared/components/BottomNavigator/BottomNavigator.tsx
+++ b/src/shared/components/BottomNavigator/BottomNavigator.tsx
@@ -1,9 +1,8 @@
 import classNames from 'classnames/bind';
 import { useRouter } from 'next/router';
 
-import DrawerContents from '@/features/home/components/DrawerContents';
-import Drawer from '@/shared/components/Drawer';
 import Icon from '@/shared/components/Icon';
+import StatisticsDrawer from '@/shared/components/StatisticsDrawer';
 import { useModal } from '@/shared/hooks/useModal';
 import { Statistics } from '@/shared/types/record/statistics';
 
@@ -54,9 +53,7 @@ const BottomNavigator = ({ statistics }: BottomNavigatorProps) => {
           </button>
         </div>
       </nav>
-      <Drawer isOpen={isDrawerOpen} onClose={closeDrawer}>
-        <DrawerContents statistics={statistics} />
-      </Drawer>
+      <StatisticsDrawer isDrawerOpen={isDrawerOpen} closeDrawer={closeDrawer} />
     </>
   );
 };

--- a/src/shared/components/StatisticsDrawer/StatisticsDrawer.stories.tsx
+++ b/src/shared/components/StatisticsDrawer/StatisticsDrawer.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import StatisticsDrawer from './StatisticsDrawer';
+
+export default {
+  component: StatisticsDrawer,
+  args: {
+    statistics: {
+      memberId: 1,
+      email: 'test@test.com',
+      nickname: 'test',
+      recordStatisticsMap: {
+        막걸리: 1,
+        소주: 2,
+        맥주: 3,
+        와인: 4,
+        양주: 5,
+      },
+    },
+  },
+} as Meta<typeof StatisticsDrawer>;
+
+export const Default: StoryObj<typeof StatisticsDrawer> = {};

--- a/src/shared/components/StatisticsDrawer/StatisticsDrawer.tsx
+++ b/src/shared/components/StatisticsDrawer/StatisticsDrawer.tsx
@@ -1,0 +1,23 @@
+import DrawerContents from '@/features/home/components/DrawerContents';
+import { useGetStatistics } from '@/shared/apis/records/getStatistics';
+import Drawer from '@/shared/components/Drawer';
+
+type StatisticsDrawerProps = {
+  isDrawerOpen: boolean;
+  closeDrawer: () => void;
+};
+
+const StatisticsDrawer = ({
+  isDrawerOpen,
+  closeDrawer,
+}: StatisticsDrawerProps) => {
+  const { data: statistics } = useGetStatistics();
+
+  return (
+    <Drawer isOpen={isDrawerOpen} onClose={closeDrawer}>
+      <DrawerContents statistics={statistics} />
+    </Drawer>
+  );
+};
+
+export default StatisticsDrawer;

--- a/src/shared/components/StatisticsDrawer/index.ts
+++ b/src/shared/components/StatisticsDrawer/index.ts
@@ -1,0 +1,1 @@
+export { default } from './StatisticsDrawer';

--- a/src/shared/types/record/statistics.ts
+++ b/src/shared/types/record/statistics.ts
@@ -2,7 +2,5 @@ export type Statistics = {
   memberId: number;
   email: string;
   nickname: string;
-  recordStatisticsMap: {
-    [key: string]: number;
-  };
+  recordStatisticsMap: Record<string, number>;
 };

--- a/src/shared/types/record/statistics.ts
+++ b/src/shared/types/record/statistics.ts
@@ -1,0 +1,8 @@
+export type Statistics = {
+  memberId: number;
+  email: string;
+  nickname: string;
+  recordStatisticsMap: {
+    [key: string]: number;
+  };
+};


### PR DESCRIPTION
- Drawer 컴포넌트를 Home page에서 사용하도록 바꿨습니다.
- 아무래도 BottomNavigator에 달려있는게 어색하다고 생각했고, 홈페이지에서 SSR로 경험과 함께 통계를 땡겨온 후 바로 Drawer에 전달해주는게 좋다고 생각했습니다.
- 아직 그래프는 mock data입니다. 글쓰기까지 완벽하게 연동되면 마지막에 연결하겠습니다.