### PR TITLE
[FIX] next/image 나오지 않는 현상

### DIFF
--- a/src/features/feed/components/Card/Card.tsx
+++ b/src/features/feed/components/Card/Card.tsx
@@ -13,7 +13,13 @@ type CardProps = {
 const Card = ({ alt, imageUrl }: CardProps) => {
   return (
     <figure className={cx('wrapper')}>
-      <Image src={imageUrl} alt={alt} fill style={{ objectFit: 'cover' }} />
+      <Image
+        src={imageUrl}
+        alt={alt}
+        fill
+        style={{ objectFit: 'cover' }}
+        unoptimized={true}
+      />
     </figure>
   );
 };

--- a/src/pages/feed/index.tsx
+++ b/src/pages/feed/index.tsx
@@ -46,8 +46,9 @@ const FeedPage = () => {
         ))}
         {isFetching && (
           <>
-            <Skeleton width="100%" height="100%" padding="50%" />
-            <Skeleton width="100%" height="100%" padding="50%" />
+            {Array.from({ length: 2 }).map((_, index) => (
+              <Skeleton width="100%" height="100%" padding="50%" key={index} />
+            ))}
           </>
         )}
         <div ref={ref} />


### PR DESCRIPTION
- s3에서 access를 all public으로 열어주거나, cf를 이용하는 방법 등이 있긴한데 일단은 next/image의 unoptimized 속성을 true로 설정하는 것으로 해결했습니다.