### PR TITLE
feat: 이미지 확장자 제한, 플레이버 기본 스코어 지정

### DIFF
--- a/src/features/record/components/FlavorSliderGroup/FlavorSliderGroup.tsx
+++ b/src/features/record/components/FlavorSliderGroup/FlavorSliderGroup.tsx
@@ -20,6 +20,8 @@ type FlavorSliderGroupProps = {
   onChange?: (value: Flavor) => void;
 };
 
+const DEFAULT_FLAVOR_SCORE = 3;
+
 const FlavorSliderGroup = forwardRef(
   (
     {
@@ -47,7 +49,7 @@ const FlavorSliderGroup = forwardRef(
           <label htmlFor="scentScore">향</label>
           <Slider
             name="scentScore"
-            value={value.scentScore}
+            value={value.scentScore ?? DEFAULT_FLAVOR_SCORE}
             onChange={handleSliderChange('scentScore')}
             min={1}
             max={5}
@@ -58,7 +60,7 @@ const FlavorSliderGroup = forwardRef(
           <label htmlFor="tasteScore">맛</label>
           <Slider
             name="tasteScore"
-            value={value.tasteScore}
+            value={value.tasteScore ?? DEFAULT_FLAVOR_SCORE}
             onChange={handleSliderChange('tasteScore')}
             min={1}
             max={5}
@@ -69,7 +71,7 @@ const FlavorSliderGroup = forwardRef(
           <label htmlFor="textureScore">감촉</label>
           <Slider
             name="textureScore"
-            value={value.textureScore}
+            value={value.textureScore ?? DEFAULT_FLAVOR_SCORE}
             onChange={handleSliderChange('textureScore')}
             min={1}
             max={5}

--- a/src/features/record/components/ImageSwiper/ImageSwiper.tsx
+++ b/src/features/record/components/ImageSwiper/ImageSwiper.tsx
@@ -24,6 +24,13 @@ type ImageSwiperProps = {
   max?: number;
 };
 
+const ALLOWED_IMAGE_TYPES = [
+  'image/jpg',
+  'image/jpeg',
+  'image/png',
+  'image/heic',
+];
+
 const ImageSwiper = ({
   mode = 'read',
   images: defaultImages = [],
@@ -45,6 +52,13 @@ const ImageSwiper = ({
     );
   };
 
+  const checkImageType = (files: File[]) => {
+    if (!files.every((file) => ALLOWED_IMAGE_TYPES.includes(file.type))) {
+      alert('허용되지 않는 이미지 형식입니다.');
+      return;
+    }
+  };
+
   const addImages = (e: ChangeEvent<HTMLInputElement>) => {
     const imageFiles = e.target.files;
     if (!imageFiles) {
@@ -57,6 +71,8 @@ const ImageSwiper = ({
       alert('이미지만 업로드 가능합니다.');
       return;
     }
+
+    checkImageType(imageFilesArray);
 
     if (images.length + imageFilesArray.length > max) {
       alert(`이미지는 최대 ${max}장까지 업로드 가능합니다.`);


### PR DESCRIPTION
- 이미지 확장자 (jpg, jpeg, png, heic)만 허용
  - 이외의 경우에는 alert과 함께 return
- 플레이버 기본 스코어를 3으로 지정

<img width="679" alt="image" src="https://github.com/sullog-official/sullog-client/assets/62709718/0d9bf7f0-8196-4ffe-b2e5-caf936ff2706">
