### PR TITLE
feat: Confirm 모달 추가

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,6 +1,7 @@
 import { QueryClientProvider } from '@tanstack/react-query';
 
 import { queryClient } from '@/shared/configs/reactQuery';
+import ConfirmProvider from '@/shared/components/ConfirmProvider';
 import '@styles/index.scss';
 
 export const parameters = {
@@ -31,7 +32,9 @@ export const decorators = [
         `}
       </style>
       <QueryClientProvider client={queryClient}>
-        <Story />
+        <ConfirmProvider>
+          <Story />
+        </ConfirmProvider>
       </QueryClientProvider>
     </>
   ),

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -3,6 +3,7 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import type { AppProps } from 'next/app';
 import { useState } from 'react';
 
+import ConfirmProvider from '@/shared/components/ConfirmProvider';
 import { queryClient as sullogQueryClient } from '@/shared/configs/reactQuery';
 
 import '@/assets/styles/index.scss';
@@ -13,7 +14,9 @@ export default function App({ Component, pageProps }: AppProps) {
   return (
     <QueryClientProvider client={queryClient}>
       <Hydrate state={pageProps.dehydratedState}>
-        <Component {...pageProps} />
+        <ConfirmProvider>
+          <Component {...pageProps} />
+        </ConfirmProvider>
       </Hydrate>
       <ReactQueryDevtools />
     </QueryClientProvider>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -11,7 +11,7 @@ import BottomNavigator from '@/shared/components/BottomNavigator';
 import Icon from '@/shared/components/Icon';
 import PageLayout from '@/shared/components/PageLayout';
 import TopNavigator from '@/shared/components/TopNavigator';
-import { useModal } from '@/shared/hooks/useModal';
+import { useOpen } from '@/shared/hooks/useOpen';
 
 import styles from './index.module.scss';
 
@@ -29,7 +29,7 @@ export default function Home() {
     showMyRecordSearchModal,
     openMyRecordSearchModal,
     closeMyRecordSearchModal,
-  ] = useModal();
+  ] = useOpen();
 
   const [showFilter, setShowFilter] = useState(false);
   const [selectedFilters, setSelectedFilters] = useState<string[]>([]);

--- a/src/shared/components/Accordion/Accordion.tsx
+++ b/src/shared/components/Accordion/Accordion.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames/bind';
 import { ReactNode } from 'react';
 
 import Icon from '@/shared/components/Icon';
-import { useModal } from '@/shared/hooks/useModal';
+import { useOpen } from '@/shared/hooks/useOpen';
 
 import styles from './Accordion.module.scss';
 
@@ -21,7 +21,7 @@ const Accordion = ({
   children,
   maxHeight = DEFAULT_MAX_HEIGHT,
 }: AccordionProps) => {
-  const [isOpen, open, close] = useModal();
+  const [isOpen, open, close] = useOpen();
 
   return (
     <div className={cx('accordion')}>

--- a/src/shared/components/BottomNavigator/BottomNavigator.tsx
+++ b/src/shared/components/BottomNavigator/BottomNavigator.tsx
@@ -4,7 +4,7 @@ import { useRouter } from 'next/router';
 
 import Icon from '@/shared/components/Icon';
 import StatisticsDrawer from '@/shared/components/StatisticsDrawer';
-import { useModal } from '@/shared/hooks/useModal';
+import { useOpen } from '@/shared/hooks/useOpen';
 import { Statistics } from '@/shared/types/record/statistics';
 
 import styles from './BottomNavigator.module.scss';
@@ -23,12 +23,12 @@ type BottomNavigatorProps = {
 const BottomNavigator = ({ statistics, currentPage }: BottomNavigatorProps) => {
   const router = useRouter();
 
-  const [isDrawerOpen, openDrawer, closeDrawer] = useModal();
+  const [isDrawerOpen, openDrawer, closeDrawer] = useOpen();
   const [
     isAlcoholSearchModalOpen,
     openAlcoholSearchModalOpen,
     closeAlcoholSearchModalOpen,
-  ] = useModal();
+  ] = useOpen();
 
   const navigateToFeed = () => {
     router.push('/feed');

--- a/src/shared/components/ConfirmModal/ConfirmModal.module.scss
+++ b/src/shared/components/ConfirmModal/ConfirmModal.module.scss
@@ -1,0 +1,20 @@
+@use '@styles/themes';
+
+.content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 10px 0;
+  text-align: center;
+  white-space: pre-wrap;
+}
+
+.message {
+  @include themes.typography('body16', 500);
+}
+
+.description {
+  margin-top: 8px;
+  color: themes.$grey500;
+  @include themes.typography('body14');
+}

--- a/src/shared/components/ConfirmModal/ConfirmModal.stories.tsx
+++ b/src/shared/components/ConfirmModal/ConfirmModal.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import ConfirmModal from './ConfirmModal';
+
+export default {
+  component: ConfirmModal,
+  args: {
+    isOpen: true,
+    message: '로그아웃 하시겠습니까?',
+    description: '진짜 진짜 진짜 진짜 진짜로 로그아웃 됩니다',
+  },
+} as Meta<typeof ConfirmModal>;
+
+export const Default: StoryObj<typeof ConfirmModal> = {};

--- a/src/shared/components/ConfirmModal/ConfirmModal.stories.tsx
+++ b/src/shared/components/ConfirmModal/ConfirmModal.stories.tsx
@@ -1,4 +1,9 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryFn, StoryObj } from '@storybook/react';
+
+import useConfirm from '@/shared/hooks/useConfirm';
+
+import Button from '../Button';
+import PageLayout from '../PageLayout';
 
 import ConfirmModal from './ConfirmModal';
 
@@ -12,3 +17,48 @@ export default {
 } as Meta<typeof ConfirmModal>;
 
 export const Default: StoryObj<typeof ConfirmModal> = {};
+
+export const UseConfirmFunction: StoryFn<typeof ConfirmModal> = () => {
+  const { confirm } = useConfirm();
+
+  const asyncPrint = (string: string) => {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        console.log(string);
+        resolve(true);
+      }, 1000);
+    });
+  };
+
+  const handleClick = async () => {
+    await confirm({
+      message: 'a 모달입니다.',
+      description:
+        '확인을 누르면 비동기 작업이 실행되고\n작업이 끝난 후 b 모달이 열립니다.',
+      onOk: async () => {
+        await asyncPrint('a 확인');
+      },
+      onCancel: () => {
+        console.log('a 취소');
+      },
+    });
+
+    await confirm({
+      message: 'bbbb',
+      onOk: async () => {
+        await asyncPrint('b 확인');
+      },
+      onCancel: async () => {
+        console.log('b 취소');
+      },
+    });
+  };
+
+  return (
+    <PageLayout>
+      <Button onClick={handleClick}>confirm</Button>
+    </PageLayout>
+  );
+};
+
+UseConfirmFunction.storyName = 'confirm 함수 사용';

--- a/src/shared/components/ConfirmModal/ConfirmModal.stories.tsx
+++ b/src/shared/components/ConfirmModal/ConfirmModal.stories.tsx
@@ -31,7 +31,7 @@ export const UseConfirmFunction: StoryFn<typeof ConfirmModal> = () => {
   };
 
   const handleClick = async () => {
-    await confirm({
+    const aModalResult = await confirm({
       message: 'a 모달입니다.',
       description:
         '확인을 누르면 비동기 작업이 실행되고\n작업이 끝난 후 b 모달이 열립니다.',
@@ -43,15 +43,18 @@ export const UseConfirmFunction: StoryFn<typeof ConfirmModal> = () => {
       },
     });
 
-    await confirm({
-      message: 'bbbb',
-      onOk: async () => {
-        await asyncPrint('b 확인');
-      },
-      onCancel: async () => {
-        console.log('b 취소');
-      },
-    });
+    if (aModalResult) {
+      await confirm({
+        message: 'bbbb',
+        description: 'a 모달에서 확인을 눌렀을 경우에만 열립니다',
+        onOk: async () => {
+          await asyncPrint('b 확인');
+        },
+        onCancel: async () => {
+          console.log('b 취소');
+        },
+      });
+    }
   };
 
   return (

--- a/src/shared/components/ConfirmModal/ConfirmModal.tsx
+++ b/src/shared/components/ConfirmModal/ConfirmModal.tsx
@@ -6,7 +6,7 @@ import styles from './ConfirmModal.module.scss';
 
 const cx = classNames.bind(styles);
 
-type ConfirmModalProps = {
+export type ConfirmModalProps = {
   isOpen: boolean;
   onClose: VoidFunction;
   /** 메시지 */

--- a/src/shared/components/ConfirmModal/ConfirmModal.tsx
+++ b/src/shared/components/ConfirmModal/ConfirmModal.tsx
@@ -1,0 +1,44 @@
+import classNames from 'classnames/bind';
+
+import Modal from '../Modal';
+
+import styles from './ConfirmModal.module.scss';
+
+const cx = classNames.bind(styles);
+
+type ConfirmModalProps = {
+  isOpen: boolean;
+  onClose: VoidFunction;
+  /** 메시지 */
+  message: string;
+  /** 설명 */
+  description?: string;
+  /** 확인 버튼 문구 (default: '확인') */
+  okText?: string;
+  onOk?: VoidFunction;
+  /** 취소 버튼 문구 (default: '취소') */
+  cancelText?: string;
+  onCancel?: VoidFunction;
+  /** 취소 버튼 숨김 여부 */
+  hideCancelButton?: boolean;
+};
+
+const ConfirmModal = ({
+  message,
+  description,
+  ...modalProps
+}: ConfirmModalProps) => {
+  return (
+    <Modal
+      {...modalProps}
+      content={
+        <div className={cx('content')}>
+          <p className={cx('message')}>{message}</p>
+          {description && <p className={cx('description')}>{description}</p>}
+        </div>
+      }
+    />
+  );
+};
+
+export default ConfirmModal;

--- a/src/shared/components/ConfirmModal/index.ts
+++ b/src/shared/components/ConfirmModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ConfirmModal';

--- a/src/shared/components/ConfirmProvider/ConfirmProvider.tsx
+++ b/src/shared/components/ConfirmProvider/ConfirmProvider.tsx
@@ -1,0 +1,25 @@
+import { ReactNode } from 'react';
+
+import {
+  ConfirmContext,
+  useConfirmReducer,
+} from '@/shared/stores/ConfirmContext';
+
+import { GlobalConfirmModal } from './GlobalConfirmModal';
+
+type ConfirmProviderProps = {
+  children: ReactNode;
+};
+
+const ConfirmProvider = ({ children }: ConfirmProviderProps) => {
+  const [state, dispatch] = useConfirmReducer();
+
+  return (
+    <ConfirmContext.Provider value={[state, dispatch]}>
+      {children}
+      <GlobalConfirmModal />
+    </ConfirmContext.Provider>
+  );
+};
+
+export default ConfirmProvider;

--- a/src/shared/components/ConfirmProvider/GlobalConfirmModal.tsx
+++ b/src/shared/components/ConfirmProvider/GlobalConfirmModal.tsx
@@ -1,0 +1,37 @@
+import { useContext } from 'react';
+
+import { confirmResolveCallback } from '@/shared/hooks/useConfirm';
+import { ConfirmContext } from '@/shared/stores/ConfirmContext';
+
+import ConfirmModal from '../ConfirmModal';
+
+export const GlobalConfirmModal = () => {
+  const [confirmState, dispatch] = useContext(ConfirmContext);
+
+  const closeConfirm = () => {
+    dispatch({
+      type: 'CLOSE',
+    });
+  };
+
+  const onOk = async () => {
+    await confirmState.onOk?.();
+    closeConfirm();
+    confirmResolveCallback(true);
+  };
+
+  const onCancel = async () => {
+    await confirmState.onCancel?.();
+    closeConfirm();
+    confirmResolveCallback(false);
+  };
+
+  return (
+    <ConfirmModal
+      {...confirmState}
+      onClose={closeConfirm}
+      onOk={onOk}
+      onCancel={onCancel}
+    />
+  );
+};

--- a/src/shared/components/ConfirmProvider/index.ts
+++ b/src/shared/components/ConfirmProvider/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ConfirmProvider';

--- a/src/shared/components/Modal/Modal.module.scss
+++ b/src/shared/components/Modal/Modal.module.scss
@@ -1,0 +1,71 @@
+@use '@styles/themes';
+
+.modal {
+  display: flex;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  flex-direction: column;
+  width: 80%;
+  max-height: 60%;
+  overflow: hidden;
+  transform: translate(-50%, -50%);
+  border-radius: 24px;
+  opacity: 0;
+  background-color: themes.$white;
+
+  &.open {
+    animation: slide-up 0.3s forwards;
+  }
+
+  &:not(.open) {
+    animation: slide-down 0.3s forwards;
+  }
+}
+
+@keyframes slide-up {
+  from {
+    top: 55%;
+    opacity: 0;
+  }
+
+  to {
+    top: 50%;
+    opacity: 1;
+  }
+}
+
+@keyframes slide-down {
+  from {
+    top: 50%;
+    opacity: 1;
+  }
+
+  to {
+    top: 55%;
+    opacity: 0;
+  }
+}
+
+.title {
+  padding: 16px;
+  text-align: center;
+  @include themes.typography('body16', 600);
+}
+
+.content {
+  margin: 0 16px 20px;
+}
+
+.button-group {
+  display: flex;
+  padding: 16px;
+
+  > * {
+    flex: 1;
+  }
+
+  > *:not(:first-child) {
+    margin-left: 10px;
+  }
+}

--- a/src/shared/components/Modal/Modal.module.scss
+++ b/src/shared/components/Modal/Modal.module.scss
@@ -54,7 +54,7 @@
 }
 
 .content {
-  margin: 0 16px 20px;
+  margin: 0 16px 16px;
 }
 
 .button-group {

--- a/src/shared/components/Modal/Modal.stories.tsx
+++ b/src/shared/components/Modal/Modal.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Modal from './Modal';
+
+export default {
+  component: Modal,
+  args: {
+    isOpen: true,
+  },
+} as Meta<typeof Modal>;
+
+export const Default: StoryObj<typeof Modal> = {
+  args: {
+    title: '알림',
+    content: <>modal 입니다.</>,
+  },
+};
+
+export const HideCancelButton: StoryObj<typeof Modal> = {
+  name: '취소 버튼 숨긴 경우',
+  args: {
+    title: '알림',
+    content: <>modal 입니다.</>,
+    hideCancelButton: true,
+  },
+};

--- a/src/shared/components/Modal/Modal.tsx
+++ b/src/shared/components/Modal/Modal.tsx
@@ -36,16 +36,6 @@ const Modal = ({
   onCancel,
   hideCancelButton,
 }: ModalProps) => {
-  const handleCancelClick = () => {
-    onCancel?.();
-    onClose();
-  };
-
-  const handleOkClick = () => {
-    onOk?.();
-    onClose();
-  };
-
   return (
     <ModalLayout isOpen={isOpen} onClose={onClose}>
       <article className={cx('modal', { open: isOpen })}>
@@ -53,11 +43,11 @@ const Modal = ({
         <div className={cx('content')}>{content}</div>
         <div className={cx('button-group')}>
           {!hideCancelButton && (
-            <Button type="outline" onClick={handleCancelClick}>
+            <Button type="outline" onClick={onCancel}>
               {cancelText}
             </Button>
           )}
-          <Button type="primary" onClick={handleOkClick}>
+          <Button type="primary" onClick={onOk}>
             {okText}
           </Button>
         </div>

--- a/src/shared/components/Modal/Modal.tsx
+++ b/src/shared/components/Modal/Modal.tsx
@@ -1,0 +1,69 @@
+import classNames from 'classnames/bind';
+import { ReactNode } from 'react';
+
+import Button from '../Button';
+import ModalLayout from '../ModalLayout';
+
+import styles from './Modal.module.scss';
+
+const cx = classNames.bind(styles);
+
+type ModalProps = {
+  isOpen: boolean;
+  onClose: VoidFunction;
+  /** 제목 */
+  title?: string;
+  /** 내용 */
+  content?: ReactNode;
+  /** 확인 버튼 문구 (default: '확인') */
+  okText?: string;
+  onOk?: VoidFunction;
+  /** 취소 버튼 문구 (default: '취소') */
+  cancelText?: string;
+  onCancel?: VoidFunction;
+  /** 취소 버튼 숨김 여부 */
+  hideCancelButton?: boolean;
+};
+
+const Modal = ({
+  isOpen,
+  onClose,
+  title,
+  content,
+  okText = '확인',
+  onOk,
+  cancelText = '취소',
+  onCancel,
+  hideCancelButton,
+}: ModalProps) => {
+  const handleCancelClick = () => {
+    onCancel?.();
+    onClose();
+  };
+
+  const handleOkClick = () => {
+    onOk?.();
+    onClose();
+  };
+
+  return (
+    <ModalLayout isOpen={isOpen} onClose={onClose}>
+      <article className={cx('modal', { open: isOpen })}>
+        <div className={cx('title')}>{title && <h1>{title}</h1>}</div>
+        <div className={cx('content')}>{content}</div>
+        <div className={cx('button-group')}>
+          {!hideCancelButton && (
+            <Button type="outline" onClick={handleCancelClick}>
+              {cancelText}
+            </Button>
+          )}
+          <Button type="primary" onClick={handleOkClick}>
+            {okText}
+          </Button>
+        </div>
+      </article>
+    </ModalLayout>
+  );
+};
+
+export default Modal;

--- a/src/shared/components/Modal/index.ts
+++ b/src/shared/components/Modal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Modal';

--- a/src/shared/components/ModalLayout/ModalLayout.module.scss
+++ b/src/shared/components/ModalLayout/ModalLayout.module.scss
@@ -13,7 +13,7 @@
   margin: 0 auto;
   overflow: hidden;
 
-  &.open {
+  &:not(.open) {
     pointer-events: none;
   }
 }

--- a/src/shared/components/ModalLayout/ModalLayout.tsx
+++ b/src/shared/components/ModalLayout/ModalLayout.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames/bind';
 import { ReactNode, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 
-import { useModal } from '@/shared/hooks/useModal';
+import { useOpen } from '@/shared/hooks/useOpen';
 
 import styles from './ModalLayout.module.scss';
 
@@ -38,7 +38,7 @@ export default ModalLayout;
 
 const useModalLayoutVisible = (isOpen: boolean) => {
   const dimRef = useRef<HTMLDivElement>(null);
-  const [isVisible, show, hide] = useModal(isOpen);
+  const [isVisible, show, hide] = useOpen(isOpen);
 
   useEffect(() => {
     if (isOpen) {

--- a/src/shared/hooks/useAuth.ts
+++ b/src/shared/hooks/useAuth.ts
@@ -15,8 +15,11 @@ import { generateUrl } from '@/shared/utils/generateUrl';
 
 import { refreshTokens } from '../apis/auth/refreshTokens';
 
+import useConfirm from './useConfirm';
+
 const useAuth = () => {
   const router = useRouter();
+  const { confirm } = useConfirm();
 
   const getKakaoOAuthAuthorizeUrl = () => {
     return generateUrl({
@@ -38,10 +41,17 @@ const useAuth = () => {
     alert('준비중입니다!');
   };
 
-  const logout = () => {
-    removeAccessToken();
-    removeRefreshToken();
-    router.push('/login');
+  const logout = async () => {
+    if (
+      await confirm({
+        message: '로그아웃 하시겠습니까?',
+        okText: '로그아웃',
+      })
+    ) {
+      removeAccessToken();
+      removeRefreshToken();
+      router.push('/login');
+    }
   };
 
   const verifyLoggedIn = async (): Promise<boolean> => {

--- a/src/shared/hooks/useConfirm.ts
+++ b/src/shared/hooks/useConfirm.ts
@@ -1,0 +1,25 @@
+import {
+  useConfirmContext,
+  ConfirmOpenPayload,
+} from '../stores/ConfirmContext';
+
+export let confirmResolveCallback: (value: boolean) => void;
+
+const useConfirm = () => {
+  const [, dispatch] = useConfirmContext();
+
+  const confirm = (payload: ConfirmOpenPayload) => {
+    dispatch({
+      type: 'OPEN',
+      payload,
+    });
+
+    return new Promise((resolve) => {
+      confirmResolveCallback = resolve;
+    });
+  };
+
+  return { confirm };
+};
+
+export default useConfirm;

--- a/src/shared/hooks/useOpen.ts
+++ b/src/shared/hooks/useOpen.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react';
 
-export const useModal = (
+export const useOpen = (
   defaultOpen: boolean = false
 ): [boolean, VoidFunction, VoidFunction] => {
   const [isOpen, setIsOpen] = useState(defaultOpen);

--- a/src/shared/stores/ConfirmContext.ts
+++ b/src/shared/stores/ConfirmContext.ts
@@ -1,0 +1,55 @@
+import { createContext, Dispatch, useContext, useReducer } from 'react';
+
+import { ConfirmModalProps } from '../components/ConfirmModal/ConfirmModal';
+
+export type ConfirmState = Omit<ConfirmModalProps, 'onClose'>;
+
+export type ConfirmOpenPayload = Omit<ConfirmModalProps, 'isOpen' | 'onClose'>;
+
+export type ConfirmAction =
+  | {
+      type: 'OPEN';
+      payload?: ConfirmOpenPayload;
+    }
+  | {
+      type: 'CLOSE';
+    };
+
+const initialConfirmState: ConfirmState = {
+  isOpen: false,
+  message: '',
+};
+
+const confirmReducer = (
+  state: ConfirmState,
+  action: ConfirmAction
+): ConfirmState => {
+  switch (action.type) {
+    case 'OPEN':
+      return {
+        /** 새로운 모달을 띄울때 이전 상태를 보존하면 안됨  */
+        ...initialConfirmState,
+        ...action.payload,
+        isOpen: true,
+      };
+    case 'CLOSE':
+      return {
+        ...state,
+        isOpen: false,
+      };
+    default:
+      return initialConfirmState;
+  }
+};
+
+export const useConfirmReducer = () => {
+  return useReducer(confirmReducer, initialConfirmState);
+};
+
+export const ConfirmContext = createContext<
+  [ConfirmState, Dispatch<ConfirmAction>]
+>([initialConfirmState, () => null]);
+
+export const useConfirmContext = () => {
+  return useContext(ConfirmContext);
+};


### PR DESCRIPTION
resolve #131

- ConfirmProvider
- useConfirm 훅 추가
- useModal -> useOpen으로 변경  (useModal 이 모달을 사용하는 훅 이름으로 헷갈릴 수 있을 것 같아서)

[스토리북](https://sullog-official.github.io/sullog-client/?path=/story/shared-components-confirmmodal--default)


resolve #130 

- 로그아웃 모달 띄우기
<img width="503" alt="image" src="https://github.com/sullog-official/sullog-client/assets/39763891/a3b57a2f-f0e1-4e01-ab54-c77089bd2e25">
