### PR TITLE
feat: 기록이 존재하지 않을 때 UI 개발

### DIFF
--- a/src/features/home/components/DrawerContents/DrawerContents.module.scss
+++ b/src/features/home/components/DrawerContents/DrawerContents.module.scss
@@ -55,6 +55,17 @@
   padding-bottom: 100%;
 }
 
+.no-data {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  color: themes.$grey300;
+  gap: 8px;
+
+  @include themes.typography('body14');
+}
+
 .button-container {
   display: flex;
   flex-direction: column;

--- a/src/features/home/components/DrawerContents/DrawerContents.tsx
+++ b/src/features/home/components/DrawerContents/DrawerContents.tsx
@@ -1,4 +1,5 @@
 import classNames from 'classnames/bind';
+import Link from 'next/link';
 
 import { mapoFlowerIsland } from '@/assets/styles/fonts';
 import DoughnutChart from '@/features/home/components/DoughnutChart';
@@ -37,9 +38,16 @@ const DrawerContents = ({ statistics }: DrawerContentsProps) => {
       <div className={cx('chart-container')}>
         <p style={mapoFlowerIsland.style}>나의 술로그</p>
         <DoughnutChart statistics={statistics} />
-        <p>
-          {statistics?.nickname}님은 {recordsCount}개의 술로그를 남겨주었어요
-        </p>
+        {recordsCount ? (
+          <p>
+            {statistics?.nickname}님은 {recordsCount}개의 술로그를 남겨주었어요
+          </p>
+        ) : (
+          <div>
+            <span>아직 술로그를 작성하지 않았어요.</span>
+            <Link href="/records/create">술로그 작성하러 가기</Link>
+          </div>
+        )}
       </div>
       <div className={cx('button-container')}>
         <Button onClick={onClickContact}>문의하기</Button>

--- a/src/features/home/components/DrawerContents/DrawerContents.tsx
+++ b/src/features/home/components/DrawerContents/DrawerContents.tsx
@@ -43,10 +43,10 @@ const DrawerContents = ({ statistics }: DrawerContentsProps) => {
             {statistics?.nickname}님은 {recordsCount}개의 술로그를 남겨주었어요
           </p>
         ) : (
-          <div>
+          <p>
             <span>아직 술로그를 작성하지 않았어요.</span>
             <Link href="/records/create">술로그 작성하러 가기</Link>
-          </div>
+          </p>
         )}
       </div>
       <div className={cx('button-container')}>

--- a/src/features/home/components/DrawerContents/DrawerContents.tsx
+++ b/src/features/home/components/DrawerContents/DrawerContents.tsx
@@ -35,20 +35,22 @@ const DrawerContents = ({ statistics }: DrawerContentsProps) => {
         </p>
         <p>오늘도 나만의 술로그를 남겨보아요</p>
       </div>
-      <div className={cx('chart-container')}>
-        <p style={mapoFlowerIsland.style}>나의 술로그</p>
-        <DoughnutChart statistics={statistics} />
-        {recordsCount ? (
+      {recordsCount < 0 ? (
+        <div className={cx('chart-container')}>
+          <p style={mapoFlowerIsland.style}>나의 술로그</p>
+          <DoughnutChart statistics={statistics} />
           <p>
             {statistics?.nickname}님은 {recordsCount}개의 술로그를 남겨주었어요
           </p>
-        ) : (
-          <p>
+        </div>
+      ) : (
+        <div>
+          <p className={cx('no-data')}>
             <span>아직 술로그를 작성하지 않았어요.</span>
-            <Link href="/records/create">술로그 작성하러 가기</Link>
+            <span>술로그로 가득 채워보세요!</span>
           </p>
-        )}
-      </div>
+        </div>
+      )}
       <div className={cx('button-container')}>
         <Button onClick={onClickContact}>문의하기</Button>
         <Button type="outline" onClick={logout}>

--- a/src/features/search/components/AlcoholSearchModal/AlcoholSearchModal.module.scss
+++ b/src/features/search/components/AlcoholSearchModal/AlcoholSearchModal.module.scss
@@ -59,3 +59,14 @@
     }
   }
 }
+
+.error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: calc(100vh - themes.$topNavigatorHeight - themes.$bottomNavigatorHeight);
+  color: themes.$grey300;
+
+  @include themes.typography('body14');
+}

--- a/src/features/search/components/AlcoholSearchModal/AlcoholSearchModal.tsx
+++ b/src/features/search/components/AlcoholSearchModal/AlcoholSearchModal.tsx
@@ -1,5 +1,4 @@
 import classNames from 'classnames/bind';
-import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 
@@ -20,11 +19,12 @@ type AlcoholSearchModalProps = {
 const AlcoholSearchModal = ({ onClose }: AlcoholSearchModalProps) => {
   const router = useRouter();
   const [searchValue, setSearchValue] = useState('');
-  const { data, fetchNextPage, hasNextPage, isLoading } = useSearchAlcohol({
-    variables: { keyword: searchValue, limit: 20, cursor: 1 },
-    enabled: searchValue !== '',
-    keepPreviousData: true,
-  });
+  const { data, fetchNextPage, hasNextPage, isLoading, isError } =
+    useSearchAlcohol({
+      variables: { keyword: searchValue, limit: 20, cursor: 1 },
+      enabled: searchValue !== '',
+      keepPreviousData: true,
+    });
 
   const onClickItem = (alcoholId: number) => {
     router.push(`/records/create?alcoholId=${alcoholId}`);
@@ -44,29 +44,38 @@ const AlcoholSearchModal = ({ onClose }: AlcoholSearchModalProps) => {
       </TopNavigator>
       <div className={cx('wrapper')}>
         <div className={cx('result-wrapper')}>
-          <div className={cx('label')}>해당하는 술을 선택해주세요.</div>
-          <div className={cx('alcohol-card-wrapper')}>
-            {data?.pages
-              .flatMap((page) => page.alcoholInfoDtoList)
-              .map((alcohol) => {
-                return (
-                  <button
-                    type="button"
-                    className={cx('alcohol-card')}
-                    onClick={() => onClickItem(alcohol.alcoholId)}
-                    key={alcohol.alcoholId}
-                  >
-                    <div className={cx('alcohol-info')}>
-                      <span>{alcohol.alcoholType}</span>
-                      <span>{alcohol.brandName}</span>
-                    </div>
-                    <span className={cx('alcohol-name')}>
-                      {alcohol.alcoholName}
-                    </span>
-                  </button>
-                );
-              })}
-          </div>
+          {isError ? (
+            <div className={cx('error')}>
+              <span>페이지를 불러오는데 실패했습니다.</span>
+              <span>잠시 후에 다시 접속해주세요.</span>
+            </div>
+          ) : (
+            <>
+              <div className={cx('label')}>해당하는 술을 선택해주세요.</div>
+              <div className={cx('alcohol-card-wrapper')}>
+                {data?.pages
+                  .flatMap((page) => page.alcoholInfoDtoList)
+                  .map((alcohol) => {
+                    return (
+                      <button
+                        type="button"
+                        className={cx('alcohol-card')}
+                        onClick={() => onClickItem(alcohol.alcoholId)}
+                        key={alcohol.alcoholId}
+                      >
+                        <div className={cx('alcohol-info')}>
+                          <span>{alcohol.alcoholType}</span>
+                          <span>{alcohol.brandName}</span>
+                        </div>
+                        <span className={cx('alcohol-name')}>
+                          {alcohol.alcoholName}
+                        </span>
+                      </button>
+                    );
+                  })}
+              </div>
+            </>
+          )}
         </div>
       </div>
     </PageLayout>

--- a/src/pages/feed/index.module.scss
+++ b/src/pages/feed/index.module.scss
@@ -1,5 +1,18 @@
-.wrapper {
+@use '@styles/themes';
+
+.grid {
   display: grid;
   grid-gap: 2px;
   grid-template-columns: repeat(2, 1fr);
+}
+
+.no-data {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: calc(100vh - themes.$topNavigatorHeight - themes.$bottomNavigatorHeight);
+  color: themes.$grey300;
+
+  @include themes.typography('body14');
 }

--- a/src/pages/feed/index.tsx
+++ b/src/pages/feed/index.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames/bind';
 import { GetServerSideProps } from 'next';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
+import { useState } from 'react';
 
 import Card from '@/features/feed/components/Card';
 import { useGetFeed } from '@/shared/apis/feed/getFeed';
@@ -18,8 +19,10 @@ import styles from './index.module.scss';
 const cx = classNames.bind(styles);
 
 const FeedPage = () => {
+  const [isFirstFetching, setIsFirstFetching] = useState<boolean>(true);
+
   const { pathname } = useRouter();
-  const { data, fetchNextPage, hasNextPage, isFetching, isLoading } =
+  const { data, fetchNextPage, hasNextPage, isFetching, isFetched } =
     useGetFeed({
       variables: {
         cursor: 0,
@@ -27,34 +30,58 @@ const FeedPage = () => {
       },
     });
 
+  if (isFetched && isFirstFetching) setIsFirstFetching(false);
+
   const ref = useIntersect(async (entry, observer) => {
     observer.unobserve(entry.target);
-    if (hasNextPage && !isFetching) {
-      fetchNextPage();
-    }
+    if (hasNextPage && !isFetching) fetchNextPage();
   });
 
-  if (!data) return null;
-  const feeds: Feed[] = data.pages.flatMap((page) => page.allRecordMetaList);
+  const feeds: Feed[] =
+    data?.pages.flatMap((page) => page.allRecordMetaList) || [];
 
   return (
     <PageLayout hasTopNavigatorPadding hasBottomNavigatorPadding>
       <TopNavigator title={'이웃 술로그'} highlighted />
-      <div className={cx('wrapper')}>
-        {feeds.map((feed) => (
-          <Link key={feed.recordId} href={`/records/${feed.recordId}`}>
-            <Card alt={feed.alcoholName} imageUrl={feed.mainPhotoPath} />
-          </Link>
-        ))}
-        {isFetching && (
-          <>
-            {Array.from({ length: 2 }).map((_, index) => (
-              <Skeleton width="100%" height="100%" padding="50%" key={index} />
-            ))}
-          </>
-        )}
-        <div ref={ref} />
-      </div>
+      {feeds.length < 0 ? (
+        <div className={cx('grid')}>
+          {feeds.map((feed) => (
+            <Link key={feed.recordId} href={`/records/${feed.recordId}`}>
+              <Card alt={feed.alcoholName} imageUrl={feed.mainPhotoPath} />
+            </Link>
+          ))}
+          {isFetching && isFirstFetching && (
+            <>
+              {Array.from({ length: 8 }).map((_, index) => (
+                <Skeleton
+                  width="100%"
+                  height="100%"
+                  padding="50%"
+                  key={index}
+                />
+              ))}
+            </>
+          )}
+          {isFetching && !isFirstFetching && feeds.length > 0 && (
+            <>
+              {Array.from({ length: 2 }).map((_, index) => (
+                <Skeleton
+                  width="100%"
+                  height="100%"
+                  padding="50%"
+                  key={index}
+                />
+              ))}
+            </>
+          )}
+          <div ref={ref} />
+        </div>
+      ) : (
+        <div className={cx('no-data')}>
+          <p>아직 이웃의 술로그가 없습니다.</p>
+        </div>
+      )}
+
       <BottomNavigator currentPage={pathname} />
     </PageLayout>
   );

--- a/src/pages/feed/index.tsx
+++ b/src/pages/feed/index.tsx
@@ -43,7 +43,7 @@ const FeedPage = () => {
   return (
     <PageLayout hasTopNavigatorPadding hasBottomNavigatorPadding>
       <TopNavigator title={'이웃 술로그'} highlighted />
-      {feeds.length < 0 ? (
+      {feeds.length > 0 ? (
         <div className={cx('grid')}>
           {feeds.map((feed) => (
             <Link key={feed.recordId} href={`/records/${feed.recordId}`}>

--- a/src/shared/components/StatisticsDrawer/StatisticsDrawer.module.scss
+++ b/src/shared/components/StatisticsDrawer/StatisticsDrawer.module.scss
@@ -1,0 +1,14 @@
+@use '@styles/themes';
+
+.error {
+  height: 100%;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  color: themes.$grey300;
+
+  @include themes.typography('body14')
+}

--- a/src/shared/components/StatisticsDrawer/StatisticsDrawer.tsx
+++ b/src/shared/components/StatisticsDrawer/StatisticsDrawer.tsx
@@ -1,6 +1,12 @@
+import classNames from 'classnames/bind';
+
 import DrawerContents from '@/features/home/components/DrawerContents';
 import { useGetStatistics } from '@/shared/apis/records/getStatistics';
 import Drawer from '@/shared/components/Drawer';
+
+import styles from './StatisticsDrawer.module.scss';
+
+const cx = classNames.bind(styles);
 
 type StatisticsDrawerProps = {
   isDrawerOpen: boolean;
@@ -15,7 +21,14 @@ const StatisticsDrawer = ({
 
   return (
     <Drawer isOpen={isDrawerOpen} onClose={closeDrawer}>
-      {statistics && <DrawerContents statistics={statistics} />}
+      {statistics ? (
+        <DrawerContents statistics={statistics} />
+      ) : (
+        <p className={cx('error')}>
+          데이터를 불러오는데 실패했습니다. <br />
+          잠시 후에 다시 접속해주세요.
+        </p>
+      )}
     </Drawer>
   );
 };


### PR DESCRIPTION
- Drawer를 열었을 때 사용자가 기록한 경험이 존재하지 않다면 안내 문구가 대신 보여집니다.
  - 데이터를 불러오는데 오류가 났을 경우 안내 문구가 대신 보여집니다.
- Feed 페이지로 이동하였을 때 이웃의 경험이 존재하지 않다면 안내 문구가 대신 보여집니다.
  - Feed 페이지의 스켈레톤을 개선하였습니다.