### PR TITLE
fix: add safe area inset top to TopNavigator

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -4,6 +4,7 @@ export default function Document() {
   return (
     <Html lang="en">
       <Head>
+        <meta name="viewport" content="initial-scale=1, viewport-fit=cover" />
         <link
           href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap"
           rel="stylesheet"

--- a/src/shared/components/TopNavigator/TopNavigator.module.scss
+++ b/src/shared/components/TopNavigator/TopNavigator.module.scss
@@ -8,6 +8,7 @@
   flex-direction: column;
   width: 100%;
   max-width: themes.$layoutMaxWidth;
+  padding-top: env(safe-area-inset-top);
 }
 
 .wrapper {


### PR DESCRIPTION
<img width="563" alt="image" src="https://github.com/sullog-official/sullog-client/assets/26860466/06c2e755-ae3b-43fd-942f-c03be57a9e57">

상단 안전영역 대응했습니다.