### PR TITLE
feat: height 100vh인 경우 setHeight100vh는 믹스인 사용하도록 수정

### DIFF
--- a/src/assets/styles/_mixins.module.scss
+++ b/src/assets/styles/_mixins.module.scss
@@ -49,3 +49,13 @@
   width: 100%;
   height: 100%;
 }
+
+@mixin setHeight100vh {
+  height: 100vh;
+
+  /* iOS only */
+  @supports (-webkit-touch-callout: none) {
+    /* stylelint-disable-next-line value-no-vendor-prefix */
+    height: -webkit-fill-available;
+  }
+}

--- a/src/pages/login/index.module.scss
+++ b/src/pages/login/index.module.scss
@@ -1,12 +1,13 @@
 @use '@styles/themes';
+@use '@styles/mixins.module';
 
 .main {
   display: flex;
   flex-direction: column;
   align-items: center;
   width: 100%;
-  height: 100vh;
   background-color: themes.$purple;
+  @include mixins.setHeight100vh;
 }
 
 .title-wrapper {

--- a/src/shared/components/Drawer/Drawer.module.scss
+++ b/src/shared/components/Drawer/Drawer.module.scss
@@ -1,4 +1,5 @@
 @use '@styles/themes';
+@use '@styles/mixins.module';
 
 .drawer {
   position: absolute;
@@ -6,9 +7,8 @@
   top: 0;
   bottom: 0;
   box-sizing: content-box;
-  height: 100vh;
-  /* stylelint-disable-next-line value-no-vendor-prefix */
-  height: -webkit-fill-available;
+  @include mixins.setHeight100vh;
+
   overflow: auto;
   transition: transform 0.3s ease;
   background: themes.$white;

--- a/src/shared/components/Loading/Loading.module.scss
+++ b/src/shared/components/Loading/Loading.module.scss
@@ -1,7 +1,9 @@
+@use '@styles/mixins.module';
+
 .wrapper {
   display: flex;
-  justify-content: center;
   align-items: center;
-  height: -webkit-fill-available;
+  justify-content: center;
   width: 100%;
+  @include mixins.setHeight100vh;
 }

--- a/src/shared/components/ModalLayout/ModalLayout.module.scss
+++ b/src/shared/components/ModalLayout/ModalLayout.module.scss
@@ -1,4 +1,5 @@
 @use '@styles/themes';
+@use '@styles/mixins.module';
 
 .container {
   position: fixed;
@@ -9,9 +10,9 @@
   left: 0;
   width: 100vw;
   max-width: themes.$layoutMaxWidth;
-  height: 100vh;
   margin: 0 auto;
   overflow: hidden;
+  @include mixins.setHeight100vh;
 
   &:not(.open) {
     pointer-events: none;


### PR DESCRIPTION
height가 100vh인 경우 ios 브라우저에서 화면이 잘리는 현상을 막기 위해 setHeight100vh 믹스인을 사용합니다
(이런 룰은 어디에 적어야 할까유.. wiki하나 팔까여)
<img width="394" alt="image" src="https://github.com/sullog-official/sullog-client/assets/39763891/e7eb60b8-0e75-4264-88d9-67762a64dbc6">
