### PR TITLE
fix: move meta tag to _app

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -5,6 +5,7 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import App from 'next/app';
 import type { AppContext, AppProps } from 'next/app';
 import dynamic from 'next/dynamic';
+import Head from 'next/head';
 import { useEffect, useState } from 'react';
 
 import { refreshAccessToken } from '@/shared/apis/auth/refreshAccessToken';
@@ -45,6 +46,12 @@ export default function SullogApp({
     <QueryClientProvider client={queryClient}>
       <Hydrate state={pageProps.dehydratedState}>
         <ConfirmProvider>
+          <Head>
+            <meta
+              name="viewport"
+              content="initial-scale=1, viewport-fit=cover"
+            />
+          </Head>
           {isPageLoading ? <Loading /> : <Component {...pageProps} />}
         </ConfirmProvider>
       </Hydrate>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -4,7 +4,6 @@ export default function Document() {
   return (
     <Html lang="en">
       <Head>
-        <meta name="viewport" content="initial-scale=1, viewport-fit=cover" />
         <link
           href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap"
           rel="stylesheet"


### PR DESCRIPTION
[Viewport `meta` tags should not be used in `_document.js` `<Head>`](https://nextjs.org/docs/messages/no-document-viewport-meta)

여러개의 meta 태그가 사용될 경우 하나만 적용되는 문제가 있어 _app에서 Head 내부에 작성하는 것을 권장한다고 합니다. 