### PR TITLE
fix: access replace with optional chain

### DIFF
--- a/src/shared/configs/logger.ts
+++ b/src/shared/configs/logger.ts
@@ -3,7 +3,7 @@ import { AxiosInstance, AxiosResponse } from 'axios';
 const logRequest = (res: AxiosResponse<any, any>, error = false) => {
   const status = res?.status;
   const method = res?.request._method;
-  const url = res?.request.responseURL.replace('https://', '');
+  const url = res?.request.responseURL?.replace('https://', '');
   let reqData = res?.config.data;
   if (res?.headers['Content-Type'] === 'multipart/form-data') {
     reqData = reqData ? JSON.parse(reqData) : null;


### PR DESCRIPTION
```
TypeError: Cannot read properties of undefined (reading 'replace')
    at logRequest (webpack-internal:///./src/shared/configs/logger.ts:8:41)
    at responseLogMiddleware (webpack-internal:///./src/shared/configs/logger.ts:18:38)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```
이 로그 뜨던거 고쳤습니다