### PR TITLE
fix: safe-area issues

### DIFF
--- a/src/features/search/components/AlcoholSearchModal/AlcoholSearchModal.module.scss
+++ b/src/features/search/components/AlcoholSearchModal/AlcoholSearchModal.module.scss
@@ -2,7 +2,7 @@
 @use '@styles/mixins.module';
 
 .alcohol-search-modal {
-  padding-top: 118px;
+  padding-top: calc(env(safe-area-inset-top) + 118px);
   background-color: themes.$white;
   @include mixins.pageModalStyles;
 }

--- a/src/features/search/components/MyRecordSearchModal/MyRecordSearchModal.module.scss
+++ b/src/features/search/components/MyRecordSearchModal/MyRecordSearchModal.module.scss
@@ -2,7 +2,7 @@
 @use '@styles/mixins.module';
 
 .my-record-search-modal {
-  padding-top: 118px;
+  padding-top: calc(env(safe-area-inset-top) + 118px);
   background-color: themes.$white;
   @include mixins.pageModalStyles;
 }

--- a/src/shared/components/PageLayout/PageLayout.module.scss
+++ b/src/shared/components/PageLayout/PageLayout.module.scss
@@ -5,7 +5,6 @@
   max-width: themes.$layoutMaxWidth;
   min-height: 100%;
   margin: 0 auto;
-  overflow-x: hidden;
 
   &.main--is-modal {
     position: fixed;
@@ -14,6 +13,8 @@
     left: 50%;
     transform: translateX(-50%);
   }
+
+  overflow-x: hidden;
 
   &.has-top-navigator-padding {
     padding-top: themes.$topNavigatorHeight;

--- a/src/shared/components/TopNavigator/TopNavigator.module.scss
+++ b/src/shared/components/TopNavigator/TopNavigator.module.scss
@@ -9,6 +9,14 @@
   width: 100%;
   max-width: themes.$layoutMaxWidth;
   padding-top: env(safe-area-inset-top);
+
+  &.white {
+    background-color: themes.$white;
+  }
+
+  &.transparent {
+    background-color: transparent;
+  }
 }
 
 .wrapper {
@@ -18,14 +26,6 @@
   justify-content: center;
   width: 100%;
   height: themes.$topNavigatorHeight;
-
-  &.white {
-    background-color: themes.$white;
-  }
-
-  &.transparent {
-    background-color: transparent;
-  }
 }
 
 $backButtonWidth: 40px;

--- a/src/shared/components/TopNavigator/TopNavigator.tsx
+++ b/src/shared/components/TopNavigator/TopNavigator.tsx
@@ -31,8 +31,8 @@ const TopNavigator = ({
   const router = useRouter();
 
   return (
-    <div className={cx('container')}>
-      <nav className={cx('wrapper', backgroundColor)}>
+    <div className={cx('container', backgroundColor)}>
+      <nav className={cx('wrapper')}>
         {showBackButton && (
           <button
             type="button"


### PR DESCRIPTION
<img width="608" alt="image" src="https://github.com/sullog-official/sullog-client/assets/26860466/fb7dd172-c8d7-4a8f-b4a3-5e0918937cd5">

상단 safe-area-inset이 적용되지 않아 input 아래 요소가 가려지던 문제를 고쳤습니다. 


<img width="608" alt="image" src="https://github.com/sullog-official/sullog-client/assets/26860466/d405476b-e675-40d4-8ca7-e8cccac44b67">

`TopNavigator`에서 배경색을 지정하는 부분이 자식 요소에 적용되어 의도된 대로 동작하지 않던 문제를 고쳤습니다.
