### PR TITLE
검색 모달이 올라왔을 때 바텀 네비게이션을 안보이게 함

### DIFF
--- a/src/assets/styles/themes/_z-index.module.scss
+++ b/src/assets/styles/themes/_z-index.module.scss
@@ -1,6 +1,6 @@
 $floating: 1000; // 헤더 등에 사용
-$modal: 1100;
-$bottomSheet: 1200;
+$bottomSheet: 1100;
+$modal: 1200;
 $backdrop: 1300;
 $drawer: 1400;
 $snackbar: 1500;

--- a/src/assets/styles/themes/_z-index.module.scss
+++ b/src/assets/styles/themes/_z-index.module.scss
@@ -1,6 +1,6 @@
 $floating: 1000; // 헤더 등에 사용
-$bottomSheet: 1100;
-$modal: 1200;
+$modal: 1100;
+$bottomSheet: 1200;
 $backdrop: 1300;
 $drawer: 1400;
 $snackbar: 1500;

--- a/src/features/search/components/MyRecordSearchModal/MyRecordSearchModal.tsx
+++ b/src/features/search/components/MyRecordSearchModal/MyRecordSearchModal.tsx
@@ -35,11 +35,7 @@ const MyRecordSearchModal = ({ onClose }: MyRecordSearchModalProps) => {
   };
 
   return (
-    <PageLayout
-      className={cx('my-record-search-modal')}
-      hasBottomNavigatorPadding
-      isModal
-    >
+    <PageLayout className={cx('my-record-search-modal')} isModal>
       <TopNavigator title={'나의 술로그'} highlighted onBack={onClose}>
         <div className={cx('search-bar-wrapper')}>
           <SearchBar

--- a/src/shared/components/BottomNavigator/BottomNavigator.module.scss
+++ b/src/shared/components/BottomNavigator/BottomNavigator.module.scss
@@ -2,7 +2,7 @@
 
 .wrapper {
   position: fixed;
-  z-index: themes.$modal;
+  z-index: themes.$bottomSheet;
   bottom: 0;
   box-sizing: content-box;
   width: 100%;

--- a/src/shared/components/BottomNavigator/BottomNavigator.module.scss
+++ b/src/shared/components/BottomNavigator/BottomNavigator.module.scss
@@ -2,7 +2,7 @@
 
 .wrapper {
   position: fixed;
-  z-index: themes.$bottomSheet;
+  z-index: themes.$floating;
   bottom: 0;
   box-sizing: content-box;
   width: 100%;


### PR DESCRIPTION
모달이 올라왔을 때 바텀 네비게이션을 보이지 않게 하여 안드로이드에서 키보드와 함께 바텀바가 올라오는 현상을 해결했습니다.